### PR TITLE
xsel must be invoked with -i flag to read stdin

### DIFF
--- a/imgur.sh
+++ b/imgur.sh
@@ -103,7 +103,7 @@ if type pbcopy &>/dev/null; then
 	echo -n "$clip" | pbcopy
 elif [ $DISPLAY ]; then
 	if type xsel &>/dev/null; then
-		echo -n "$clip" | xsel
+		echo -n "$clip" | xsel -i
 	elif type xclip &>/dev/null; then
 		echo -n "$clip" | xclip
 	else


### PR DESCRIPTION
Previously, xsel was invoked with no flags, causing it to output the current selection to stdout, rather than read a new selection from stdin.

This caused unexpected results when attempting to use the stdout from imgur.sh in scripts, as you would get the imgur url with the previous contents of your clipboard appended to it.

I've updated the script to use `xsel -i`, which behaves as per the documentation:

`-i, --input           Read standard input into the selection`