### PR TITLE
Change /bin/bash to /usr/bin/env bash

### DIFF
--- a/imgur.sh
+++ b/imgur.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Imgur script by Bart Nagel <bart@tremby.net>
 # Improvements by Tino Sino <robottinosino@gmail.com>


### PR DESCRIPTION
Supports systems where /bin/bash doesn't exist (For example, NixOS)